### PR TITLE
Fix make etcd operator secrets on MacOS

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,5 @@
+# Common functions used by make-* scripts
+
+function encode() {
+    cat ${1} | base64 | tr -d '\r' | tr -d '\n'
+}

--- a/make-etcd-operator-secrets.sh
+++ b/make-etcd-operator-secrets.sh
@@ -2,9 +2,7 @@
 
 set -eux
 
-function encode() {
-    cat ${1} | base64 | tr -d '\n'
-}
+source ./common.sh
 
 export CA=$(encode pki/ca.pem)
 for secret in etcd-client server peer; do

--- a/make-kube-apiserver-secrets.sh
+++ b/make-kube-apiserver-secrets.sh
@@ -2,9 +2,7 @@
 
 set -eux
 
-function encode() {
-  cat ${1} | base64 | tr -d '\n'
-}
+source ./common.sh
 
 cat > kube-apiserver/kube-apiserver-secret.yaml <<EOF 
 apiVersion: v1

--- a/make-kube-controller-manager-secrets.sh
+++ b/make-kube-controller-manager-secrets.sh
@@ -2,9 +2,7 @@
 
 set -eux
 
-function encode() {
-  cat ${1} | base64 | tr -d '\n'
-}
+source ./common.sh
 
 cat > kube-controller-manager/kube-controller-manager-secret.yaml <<EOF 
 apiVersion: v1

--- a/make-kube-scheduler-secrets.sh
+++ b/make-kube-scheduler-secrets.sh
@@ -2,9 +2,7 @@
 
 set -eux
 
-function encode() {
-  cat ${1} | base64 | tr -d '\n'
-}
+source ./common.sh
 
 cat > kube-scheduler/kube-scheduler-secret.yaml <<EOF 
 apiVersion: v1

--- a/make-openshift-apiserver-secrets.sh
+++ b/make-openshift-apiserver-secrets.sh
@@ -4,9 +4,7 @@ set -eux
 
 NAMESPACE=hosted
 
-function encode() {
-  cat ${1} | base64 | tr -d '\n'
-}
+source ./common.sh
 
 CABUNDLE="$(encode pki/ca.pem)"
 


### PR DESCRIPTION
On macos line endings contain both \n and \r (which is strange)