### PR TITLE
Parameterize Etcd operator cluster role binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /pki
 *-secret.yaml
 /openshift-apiserver/openshift-apiserver-apiservices.yaml
+/etcd/operator-cluster-role-binding.yaml

--- a/make-etcd-operator-cluster-role-binding.sh
+++ b/make-etcd-operator-cluster-role-binding.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eux
+
+envsubst < template/etcd-operator-cluster-role-binding.yaml > etcd/operator-cluster-role-binding.yaml

--- a/template/etcd-operator-cluster-role-binding.yaml
+++ b/template/etcd-operator-cluster-role-binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: etcd-operator
-  namespace: hosted
+  namespace: ${NAMESPACE}


### PR DESCRIPTION
The namespace for the cluster role binding is hardcoded to `hosted`. Switches to using the `$NAMESPACE` env var.