### PR TITLE
Fix crashlooping on control plane pods

### DIFF
--- a/kube-apiserver/config.yaml
+++ b/kube-apiserver/config.yaml
@@ -26,7 +26,6 @@ apiServerArguments:
   - 'true'
   feature-gates:
   - ExperimentalCriticalPodAnnotation=true
-  - RotateKubeletServerCertificate=true
   - SupportPodPidsLimit=true
   - LocalStorageCapacityIsolation=false
   http2-max-streams-per-connection:

--- a/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/kube-apiserver/kube-apiserver-deployment.yaml
@@ -23,10 +23,29 @@ spec:
         - kube-apiserver
         args:
         - "--openshift-config=/etc/kubernetes/config.yaml"
+        workingDir: /var/log/kube-apiserver
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            port: 6443
+            path: healthz
+          initialDelaySeconds: 45
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            port: 6443
+            path: healthz
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
         volumeMounts:
         - mountPath: /etc/kubernetes/
           name: secret
+        - mountPath: /var/log/kube-apiserver/
+          name: logs
       volumes:
       - secret:
           secretName: kube-apiserver
         name: secret
+      - emptyDir: {}
+        name: logs

--- a/kube-controller-manager/config.yaml
+++ b/kube-controller-manager/config.yaml
@@ -1,7 +1,9 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeControllerManagerConfig
 extendedArguments:
-  kubeconfig:
+  authentication-kubeconfig:
+  - "/etc/kubernetes/kubeconfig"
+  authorization-kubeconfig:
   - "/etc/kubernetes/kubeconfig"
   allocate-node-cidrs:
   - 'true'
@@ -35,13 +37,10 @@ extendedArguments:
   - '300'
   kube-api-qps:
   - '150'
+  leader-elect-resource-lock:
+  - configmaps
   leader-elect:
   - 'true'
-  # TODO: OOTB kube-controller-manager cluster role does not allow updating
-  # configmpas in kube-system.  kube-apiserver won't allow creation of
-  # rolebinding in the user cluster without on operational openshift-apiserver.
-  #leader-elect-resource-lock:
-  #- configmaps
   leader-elect-retry-period:
   - 3s
   port:

--- a/kube-controller-manager/kube-controller-manager-deployment.yaml
+++ b/kube-controller-manager/kube-controller-manager-deployment.yaml
@@ -14,7 +14,6 @@ spec:
       labels:
         app: kube-controller-manager
     spec:
-      automountServiceAccountToken: false
       containers:
       - name: kube-controller-manager
         image: ${HYPERKUBE_IMAGE}
@@ -23,10 +22,20 @@ spec:
         - kube-controller-manager
         args:
         - "--openshift-config=/etc/kubernetes/config.yaml"
+        - "--kubeconfig=/etc/kubernetes/kubeconfig"
         volumeMounts:
         - mountPath: /etc/kubernetes/
           name: secret
+        - mountPath: /var/run/kubernetes
+          name: certdir
+        - mountPath: /var/log/kube-controller-manager
+          name: logs
+        workingDir: /var/log/kube-controller-manager
       volumes:
       - secret:
           secretName: kube-controller-manager
         name: secret
+      - emptyDir: {}
+        name: logs
+      - emptyDir: {}
+        name: certdir

--- a/kube-scheduler/kube-scheduler-deployment.yaml
+++ b/kube-scheduler/kube-scheduler-deployment.yaml
@@ -31,7 +31,12 @@ spec:
         volumeMounts:
         - mountPath: /etc/kubernetes/
           name: secret
+        - mountPath: /var/run/kubernetes/
+          name: cert
+        workDir: /var/run/kubernetes
       volumes:
       - secret:
           secretName: kube-scheduler
         name: secret
+      - emptyDir: {}
+        name: cert

--- a/make-pki.sh
+++ b/make-pki.sh
@@ -194,7 +194,7 @@ generate_client_key_cert "root-ca" "kubelet-server" "system:node:${node}" "syste
 done
 
 # kube-controller-manager
-generate_client_kubeconfig "root-ca" "kube-controller-manager" "system:kube-controller-manager" "kubernetes" "kube-apiserver"
+generate_client_kubeconfig "root-ca" "kube-controller-manager" "system:admin" "system:masters" "kube-apiserver"
 if [ ! -e "service-account-key.pem" ]; then 
   openssl genrsa -out service-account-key.pem 2048
   openssl rsa -in service-account-key.pem -pubout > service-account.pem
@@ -204,7 +204,7 @@ fi
 generate_client_kubeconfig "root-ca" "kube-proxy" "system:kube-proxy" "kubernetes" "" "${EXTERNAL_API_DNS_NAME}:${EXTERNAL_API_PORT}"
 
 # kube-scheduler
-generate_client_kubeconfig "root-ca" "kube-scheduler" "system:kube-scheduler" "kubernetes"
+generate_client_kubeconfig "root-ca" "kube-scheduler" "system:admin" "system:masters"
 
 # kube-apiserver
 generate_client_key_cert "root-ca" "kube-apiserver-server" "kubernetes" "kubernetes" "${EXTERNAL_API_DNS_NAME},172.31.0.1,kubernetes,kubernetes.default.svc,kubernetes.default.svc.cluster.local,kube-apiserver,kube-apiserver.${NAMESPACE}.svc,kube-apiserver.${NAMESPACE}.svc.cluster.local"


### PR DESCRIPTION
- Added health check to kube apiserver
- Added writeable working dir to kube apiserver and controller manager for logs and other stuff
- Changed the principal for controller manager and scheduler to system:admin (this is what we do in ocp 4 today). This gets rid of the issue with the controller manager crashing because it can't create the leader election configmap.