### PR TITLE
Additional fixes for OpenShift control plane components

### DIFF
--- a/make-pki.sh
+++ b/make-pki.sh
@@ -190,6 +190,9 @@ generate_client_kubeconfig "root-ca" "admin" "system:admin" "system:masters" "" 
 # kubelet bootstrapper kubeconfig
 generate_client_kubeconfig "cluster-signer" "kubelet-bootstrap" "system:bootstrapper" "system:bootstrappers" "" "${EXTERNAL_API_DNS_NAME}:${EXTERNAL_API_PORT}"
 
+# service client admin kubeconfig
+generate_client_kubeconfig "root-ca" "service-admin" "system:admin" "system:masters" "kube-apiserver"
+
 # kube-controller-manager
 generate_client_kubeconfig "root-ca" "kube-controller-manager" "system:admin" "system:masters" "kube-apiserver"
 if [ ! -e "service-account-key.pem" ]; then 

--- a/openshift-apiserver/openshift-apiserver-deployment.yaml
+++ b/openshift-apiserver/openshift-apiserver-deployment.yaml
@@ -24,7 +24,12 @@ spec:
         volumeMounts:
         - mountPath: /etc/kubernetes/
           name: secret
+        - mountPath: /var/run/kubernetes
+          name: logs
+        workingDir: /var/run/kubernetes
       volumes:
       - secret:
           secretName: openshift-apiserver
         name: secret
+      - emptyDir: {}
+        name: logs

--- a/openshift-apiserver/render.sh
+++ b/openshift-apiserver/render.sh
@@ -14,7 +14,7 @@ kind: Secret
 metadata:
   name: openshift-apiserver
 data:
-  kubeconfig: $(encode ../pki/admin.kubeconfig)
+  kubeconfig: $(encode ../pki/service-admin.kubeconfig)
   server.crt: $(encode ../pki/openshift-apiserver-server.pem)
   server.key: $(encode ../pki/openshift-apiserver-server-key.pem)
   etcd-client.crt: $(encode ../pki/etcd-client.pem)

--- a/openshift-controller-manager/render.sh
+++ b/openshift-controller-manager/render.sh
@@ -14,7 +14,7 @@ kind: Secret
 metadata:
   name: openshift-controller-manager
 data:
-  kubeconfig: $(encode ../pki/admin.kubeconfig)
+  kubeconfig: $(encode ../pki/service-admin.kubeconfig)
   server.crt: $(encode ../pki/openshift-controller-manager-server.pem)
   server.key: $(encode ../pki/openshift-controller-manager-server-key.pem)
   ca.crt: $(encode ../pki/root-ca.pem)


### PR DESCRIPTION
- Creates admin kubeconfig that works with the kube-apiserver service. 
- Adds empty dir volume to openshift server and makes it the working directory so the process can write to disk.
- Switches openshift apiserver and controller manager to use the kubeconfig with the service endpoint instead of the external endpoint.