### PR TITLE
Add proxy for Kube APIServer endpoint on worker nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /config.sh
 ignition-generator/fake-root/etc/kubernetes/kubeconfig
 ignition-generator/fake-root/etc/kubernetes/ca.crt
+haproxy.cfg

--- a/ignition-generator/fake-root/etc/kubernetes/apiserver-proxy-config/.gitignore
+++ b/ignition-generator/fake-root/etc/kubernetes/apiserver-proxy-config/.gitignore
@@ -1,0 +1,1 @@
+haproxy.cfg

--- a/ignition-generator/fake-root/etc/kubernetes/manifests/kube-apiserver-proxy.yaml
+++ b/ignition-generator/fake-root/etc/kubernetes/manifests/kube-apiserver-proxy.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver-proxy
+  namespace: kube-system
+  labels:
+    k8s-app: kube-apiserver-proxy
+spec:
+  hostNetwork: true
+  containers:
+  - name: haproxy
+    image: docker.io/haproxy:2.0.6
+    volumeMounts:
+    - name: config
+      mountPath: /usr/local/etc/haproxy
+  volumes:
+  - name: config
+    hostPath:
+      path: /etc/kubernetes/apiserver-proxy-config

--- a/ignition-generator/fake-root/usr/local/bin/setup-apiserver-ip.sh
+++ b/ignition-generator/fake-root/usr/local/bin/setup-apiserver-ip.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -x
+ip addr add 172.20.0.1/32 brd 172.20.0.1 scope host dev lo
+ip route add 172.20.0.1/32 dev lo scope link src 172.20.0.1

--- a/ignition-generator/fake-root/usr/local/bin/teardown-apiserver-ip.sh
+++ b/ignition-generator/fake-root/usr/local/bin/teardown-apiserver-ip.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -x
+ip addr delete 172.20.0.1/32 dev lo
+ip route del 172.20.0.1/32 dev lo scope link src 172.20.0.1

--- a/ignition-generator/haproxy.cfg.template
+++ b/ignition-generator/haproxy.cfg.template
@@ -1,0 +1,16 @@
+global
+  maxconn 32000
+
+defaults
+  mode tcp
+  timeout client 30000ms
+  timeout server 30000ms
+  timeout connect 3000ms
+  retries 3
+
+frontend local_apiserver
+  bind 172.20.0.1:6443
+  default_backend remote_apiserver
+
+backend remote_apiserver
+  server controlplane ${EXTERNAL_API_DNS_NAME}:${EXTERNAL_API_PORT}

--- a/ignition-generator/make-ignition.sh
+++ b/ignition-generator/make-ignition.sh
@@ -2,11 +2,15 @@
 
 set -eux
 
+source ../config.sh
+
 echo "copying PKI assets"
 cp ../pki/kubelet-bootstrap.kubeconfig fake-root/etc/kubernetes/kubeconfig
 # kubeconfig needs to be world readable because network-operator reads it for server URL
 chmod +r fake-root/etc/kubernetes/kubeconfig
 cp ../pki/root-ca.pem fake-root/etc/kubernetes/ca.crt
+echo "Rendering apiserver proxy cfg"
+envsubst < haproxy.cfg.template > fake-root/etc/kubernetes/apiserver-proxy-config/haproxy.cfg
 echo "transpiling files"
 ./filetranspile -i base.ign -f fake-root -o tmp.ign
 echo "transpiling units"

--- a/ignition-generator/units/apiserver-ip.service
+++ b/ignition-generator/units/apiserver-ip.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Sets up local IP to proxy API server requests
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/setup-apiserver-ip.sh
+ExecStop=/usr/local/bin/teardown-apiserver-ip.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/kube-apiserver/config.yaml
+++ b/kube-apiserver/config.yaml
@@ -39,7 +39,7 @@ apiServerArguments:
   storage-media-type:
   - application/vnd.kubernetes.protobuf
   advertise-address:
-  - "10.42.10.219"
+  - "172.20.0.1"
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true

--- a/make-pki.sh
+++ b/make-pki.sh
@@ -207,7 +207,7 @@ generate_client_kubeconfig "root-ca" "kube-proxy" "system:kube-proxy" "kubernete
 generate_client_kubeconfig "root-ca" "kube-scheduler" "system:admin" "system:masters"
 
 # kube-apiserver
-generate_client_key_cert "root-ca" "kube-apiserver-server" "kubernetes" "kubernetes" "${EXTERNAL_API_DNS_NAME},172.31.0.1,10.42.10.219,kubernetes,kubernetes.default.svc,kubernetes.default.svc.cluster.local,kube-apiserver,kube-apiserver.${NAMESPACE}.svc,kube-apiserver.${NAMESPACE}.svc.cluster.local"
+generate_client_key_cert "root-ca" "kube-apiserver-server" "kubernetes" "kubernetes" "${EXTERNAL_API_DNS_NAME},172.31.0.1,172.20.0.1,kubernetes,kubernetes.default.svc,kubernetes.default.svc.cluster.local,kube-apiserver,kube-apiserver.${NAMESPACE}.svc,kube-apiserver.${NAMESPACE}.svc.cluster.local"
 generate_client_key_cert "root-ca" "kube-apiserver-kubelet" "system:kube-apiserver" "kubernetes"
 generate_client_key_cert "root-ca" "kube-apiserver-aggregator-proxy-client" "system:openshift-aggregator" "kubernetes"
 


### PR DESCRIPTION
Adds a systemd unit to create an IP address on a worker node along with a daemonset running haproxy that forwards the IP to the user cluster's dns:port address.
This gets rid of the need for a fixed IP address and makes it possible to generate pki with a well-knonw IP.