### PR TITLE
Remove use of container cli

### DIFF
--- a/auto-approver/render.sh
+++ b/auto-approver/render.sh
@@ -2,5 +2,8 @@
 
 set -eu
 
-export CLI_IMAGE=$(${CONTAINER_CLI} run -ti --rm ${RELEASE_IMAGE} image cli)
+source ../config.sh
+source ../lib/common.sh
+
+export CLI_IMAGE=$(image_for cli)
 envsubst '$CLI_IMAGE' < auto-approver.yaml > ../manifests/managed/auto-approver.yaml

--- a/ca-operator/render.sh
+++ b/ca-operator/render.sh
@@ -15,5 +15,5 @@ data:
   kubeconfig: $(encode ../pki/admin.kubeconfig)
 EOF
 
-export CLI_IMAGE=$(${CONTAINER_CLI} run -ti --rm ${RELEASE_IMAGE} image cli)
+export CLI_IMAGE=$(image_for cli)
 envsubst '$CLI_IMAGE' < ca-operator-deployment.yaml > ../manifests/managed/ca-operator-deployment.yaml

--- a/config.sh.aws_example
+++ b/config.sh.aws_example
@@ -32,9 +32,6 @@ export EXTERNAL_API_PORT=6443
 # the cluster IP to use for openshift-apiserver
 export API_CLUSTERIP=172.30.0.20
 
-# the command to use when running containers
-export CONTAINER_CLI=podman
-
 # OKD/OCP release image from which to get component image pull specs
 export RELEASE_IMAGE=$(curl -s "https://origin-release.svc.ci.openshift.org/api/v1/releasestream/4.2.0-0.okd/latest" | jq -r .pullSpec)
 

--- a/config.sh.example
+++ b/config.sh.example
@@ -24,9 +24,6 @@ export EXTERNAL_OPENVPN_PORT=1194
 # the cluster IP to use for openshift-apiserver
 export API_CLUSTERIP=172.30.0.20
 
-# the command to use when running containers
-export CONTAINER_CLI=podman
-
 # OKD/OCP release image from which to get component image pull specs
 export RELEASE_IMAGE=$(curl -s "https://origin-release.svc.ci.openshift.org/api/v1/releasestream/4.2.0-0.okd/latest" | jq -r .pullSpec)
 

--- a/config.sh.iks_example
+++ b/config.sh.iks_example
@@ -28,13 +28,6 @@ export EXTERNAL_API_PORT=$(oc get service kube-apiserver -o jsonpath='{.spec.por
 #export API_CLUSTERIP=172.30.0.20
 export API_CLUSTERIP=$(oc get service openshift-apiserver -o jsonpath='{.spec.clusterIP}')
 
-# the command to use when running containers
-if [[ $(uname) != "Darwin" ]]; then
-    export CONTAINER_CLI=podman
-else
-    export CONTAINER_CLI=docker
-fi
-
 # OKD/OCP release image from which to get component image pull specs
 export RELEASE_IMAGE=$(curl -s "https://origin-release.svc.ci.openshift.org/api/v1/releasestream/4.2.0-0.okd/latest" | jq -r .pullSpec)
 

--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source config.sh
+source lib/common.sh
 
 export API_NODEPORT="${API_NODEPORT:-$EXTERNAL_API_PORT}"
 
@@ -16,9 +17,9 @@ set -eu
 echo "Creating PKI assets"
 ./make-pki.sh &>/dev/null
 
-echo "Pulling release image"
-touch pull-secret
-REGISTRY_AUTH_FILE=$(pwd)/pull-secret ${CONTAINER_CLI} pull ${RELEASE_IMAGE} >/dev/null
+echo "Retrieving release pull specs"
+export RELEASE_PULLSPECS="$(mktemp)"
+fetch_release_pullspecs
 
 echo "Rendering manifests"
 rm -rf manifests

--- a/kube-apiserver/render.sh
+++ b/kube-apiserver/render.sh
@@ -70,6 +70,6 @@ data:
 EOF
 rm -f client.conf.rendered
 
-export HYPERKUBE_IMAGE=$(${CONTAINER_CLI} run -ti --rm ${RELEASE_IMAGE} image hyperkube)
+export HYPERKUBE_IMAGE=$(image_for hyperkube)
 envsubst < kube-apiserver-deployment.yaml > ../manifests/managed/kube-apiserver-deployment.yaml
 envsubst < kube-apiserver-service.yaml > ../manifests/managed/kube-apiserver-service.yaml

--- a/kube-controller-manager/render.sh
+++ b/kube-controller-manager/render.sh
@@ -18,5 +18,5 @@ data:
   cluster-signer.key: $(encode ../pki/cluster-signer-key.pem)
 EOF
 
-export HYPERKUBE_IMAGE=$(${CONTAINER_CLI} run -ti --rm ${RELEASE_IMAGE} image hyperkube)
+export HYPERKUBE_IMAGE=$(image_for hyperkube)
 envsubst < kube-controller-manager-deployment.yaml > ../manifests/managed/kube-controller-manager-deployment.yaml

--- a/kube-scheduler/render.sh
+++ b/kube-scheduler/render.sh
@@ -14,5 +14,5 @@ data:
   config.yaml: $(encode config.yaml)
 EOF
 
-export HYPERKUBE_IMAGE=$(${CONTAINER_CLI} run -ti --rm ${RELEASE_IMAGE} image hyperkube)
+export HYPERKUBE_IMAGE=$(image_for hyperkube)
 envsubst < kube-scheduler-deployment.yaml > ../manifests/managed/kube-scheduler-deployment.yaml

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,3 +1,23 @@
 function encode() {
   cat ${1} | base64 | tr -d '\n' | tr -d '\r'
 }
+
+function fetch_release_pullspecs() {
+    local repodir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
+    if [[ -z "${RELEASE_PULLSPECS}" ]]; then
+      >&2 echo "Release pull specs not set"
+      exit 1
+    fi
+    oc adm release info --registry-config "${repodir}/pull-secret" "${RELEASE_IMAGE}" --pullspecs > "${RELEASE_PULLSPECS}"
+}
+
+function image_for() {
+  local name="${1}"
+
+  local pullspecs="${RELEASE_PULLSPECS:-}"
+  if [[ -z "${pullspecs}" ]]; then
+    export RELEASE_PULLSPECS="$(mktemp)"
+    fetch_release_pullspecs
+  fi
+  cat "${RELEASE_PULLSPECS}" | grep "^  ${name}\\s" | awk '{ print $2 }'
+}

--- a/openshift-apiserver/render.sh
+++ b/openshift-apiserver/render.sh
@@ -26,7 +26,7 @@ data:
 EOF
 rm -f config.yaml.rendered
 
-export OPENSHIFT_APISERVER_IMAGE=$(${CONTAINER_CLI} run -ti --rm ${RELEASE_IMAGE} image openshift-apiserver)
+export OPENSHIFT_APISERVER_IMAGE=$(image_for openshift-apiserver)
 envsubst < openshift-apiserver-deployment.yaml > ../manifests/managed/openshift-apiserver-deployment.yaml
 envsubst < openshift-apiserver-service.yaml > ../manifests/managed/openshift-apiserver-service.yaml
 

--- a/openshift-controller-manager/render.sh
+++ b/openshift-controller-manager/render.sh
@@ -4,8 +4,8 @@ set -eu
 
 source ../lib/common.sh
 
-export DOCKER_BUILDER_IMAGE=$(${CONTAINER_CLI} run -ti --rm ${RELEASE_IMAGE} image docker-builder)
-export DEPLOYER_IMAGE=$(${CONTAINER_CLI} run -ti --rm ${RELEASE_IMAGE} image deployer)
+export DOCKER_BUILDER_IMAGE=$(image_for docker-builder)
+export DEPLOYER_IMAGE=$(image_for deployer)
 envsubst < config.yaml > config.yaml.rendered
 
 cat > ../manifests/managed/openshift-controller-manager-secret.yaml <<EOF 
@@ -23,7 +23,7 @@ EOF
 
 rm -f config.yaml.rendered
 
-export OPENSHIFT_CONTROLLER_MANAGER_IMAGE=$(${CONTAINER_CLI} run -ti --rm ${RELEASE_IMAGE} image openshift-controller-manager)
+export OPENSHIFT_CONTROLLER_MANAGER_IMAGE=$(image_for openshift-controller-manager)
 envsubst < openshift-controller-manager-deployment.yaml > ../manifests/managed/openshift-controller-manager-deployment.yaml
 
 cp openshift-controller-manager-namespace.yaml ../manifests/user

--- a/user-manifests-bootstrapper/render.sh
+++ b/user-manifests-bootstrapper/render.sh
@@ -2,6 +2,7 @@
 
 set -eu
 
+source ../config.sh
 source ../lib/common.sh
 
 for f in ../manifests/user/{*.yaml,*.yml}; do
@@ -19,5 +20,5 @@ data:
   kubeconfig: $(encode ../pki/service-admin.kubeconfig)
 EOF
 
-export CLI_IMAGE=$(${CONTAINER_CLI} run -ti --rm ${RELEASE_IMAGE} image cli)
+export CLI_IMAGE=$(image_for cli)
 envsubst '$CLI_IMAGE' < user-manifests-bootstrapper.yaml > ../manifests/managed/user-manifests-bootstrapper-pod.yaml


### PR DESCRIPTION
Removes the need to call `podman/docker run` by using `oc adm release` to extract image pull specs from the release image.