### PR TITLE
Add controller manager CA configmaps (fixes builds)

### DIFF
--- a/openshift-controller-manager/render.sh
+++ b/openshift-controller-manager/render.sh
@@ -2,6 +2,7 @@
 
 set -eu
 
+source ../config.sh
 source ../lib/common.sh
 
 export DOCKER_BUILDER_IMAGE=$(${CONTAINER_CLI} run -ti --rm ${RELEASE_IMAGE} image docker-builder)
@@ -26,4 +27,14 @@ rm -f config.yaml.rendered
 export OPENSHIFT_CONTROLLER_MANAGER_IMAGE=$(${CONTAINER_CLI} run -ti --rm ${RELEASE_IMAGE} image openshift-controller-manager)
 envsubst < openshift-controller-manager-deployment.yaml > ../manifests/managed/openshift-controller-manager-deployment.yaml
 
-cp openshift-controller-manager-namespace.yaml ../manifests/user
+cp openshift-controller-manager-namespace.yaml ../manifests/user/00-openshift-controller-manager-namespace.yaml
+cat > ../manifests/user/openshift-controller-manager-service-ca.yaml <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: openshift-service-ca
+  namespace: openshift-controller-manager
+data: {}
+EOF

--- a/user-manifests-bootstrapper/user-manifests-bootstrapper.yaml
+++ b/user-manifests-bootstrapper/user-manifests-bootstrapper.yaml
@@ -38,6 +38,8 @@ spec:
       done
       export KUBECONFIG=/var/run/secrets/kubeconfig/kubeconfig
       oc apply -f $(pwd)
+      # Create the global certs configmap here because it's too large to oc apply
+      oc create configmap -n openshift-controller-manager openshift-global-ca --from-file ca-bundle.crt=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
     volumeMounts:
     - mountPath: /var/run/secrets/kubeconfig
       name: kubeconfig


### PR DESCRIPTION
Builds in 4.2 rely on 2 configmaps in the `openshift-controller-manager` namespace:
- `openshift-service-ca` - contains the cluster service CA (populated automatically by the service ca operator)
- `openshift-global-ca` - contains all the default root CA's (and any proxy ca's configured for the cluster)

The latter configmap is too big to apply through `oc apply` so I ended up modifying the user config bootstrapper pod to create it after applying all the other user configs.